### PR TITLE
Update script to use NODE_ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 /node_modules
 .DS_Store
+/dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,34 +2021,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.0.tgz",
-      "integrity": "sha512-G/B6gtkjgthT8AP/xN1wdj5Xe18fVyk58JepK8GxpUbqcz3hyWxegocMbvnZK+KoTslwd0ACZ3woi/DVUdVjyQ==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz",
-          "integrity": "sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==",
-          "dev": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "path-key": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
-          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
-          "dev": true
-        }
-      }
-    },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2021,6 +2021,34 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.0.tgz",
+      "integrity": "sha512-G/B6gtkjgthT8AP/xN1wdj5Xe18fVyk58JepK8GxpUbqcz3hyWxegocMbvnZK+KoTslwd0ACZ3woi/DVUdVjyQ==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.0.tgz",
+          "integrity": "sha512-6U/8SMK2FBNnB21oQ4+6Nsodxanw1gTkntYA2zBdkFYFu3ZDx65P2ONEXGSvob/QS6REjVHQ9zxzdOafwFdstw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "path-key": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.0.tgz",
+          "integrity": "sha512-8cChqz0RP6SHJkMt48FW0A7+qUOn+OsnOsVtzI59tZ8m+5bCSk7hzwET0pulwOM2YMn9J1efb07KB9l9f30SGg==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "start": "webpack-dev-server --inline --progress --colors",
-    "build": "webpack"
+    "start": "cross-env NODE_ENV=development webpack-dev-server --inline --progress --colors",
+    "build": "cross-env NODE_ENV=production webpack"
   },
   "keywords": [
     "webpack",
@@ -27,6 +27,7 @@
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-preset-env": "^1.6.1",
+    "cross-env": "^6.0.0",
     "css-hot-loader": "^1.4.4",
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "start": "cross-env NODE_ENV=development webpack-dev-server --inline --progress --colors",
-    "build": "cross-env NODE_ENV=production webpack"
+    "start": "NODE_ENV=development webpack-dev-server --inline --progress --colors",
+    "build": "NODE_ENV=production webpack"
   },
   "keywords": [
     "webpack",
@@ -27,7 +27,6 @@
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-preset-env": "^1.6.1",
-    "cross-env": "^6.0.0",
     "css-hot-loader": "^1.4.4",
     "css-loader": "^2.1.1",
     "html-webpack-plugin": "^3.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,12 +3,12 @@ const webpack = require('webpack');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-const devMode = process.env.NODE_ENV !== 'production';
+const env = process.env.NODE_ENV;
 
 module.exports = {
   entry: './app/index.js',
 
-  mode: 'development',
+  mode: env,
 
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -33,7 +33,7 @@ module.exports = {
       {
         test: /\.(sa|sc|c)ss$/,
         use: [
-          devMode ? 'style-loader' : MiniCssExtractPlugin.loader,
+          env == 'development' ? 'style-loader' : MiniCssExtractPlugin.loader,
           'css-loader',
           'postcss-loader',
           'sass-loader',


### PR DESCRIPTION
Currently, NODE_ENV is never set to production, so the const devMode is always true, even when running the build script. That's making Webpack to always use style-loader instead of exporting an external CSS file with MiniCssExtractPlugin.

I've also updated .gitignore to ignore /dist folder.